### PR TITLE
fix error in run_SSN_Utils_Color_SSN test handle

### DIFF
--- a/lib/EFIToolsKBase/ssnutil_wrappers/colorssn.py
+++ b/lib/EFIToolsKBase/ssnutil_wrappers/colorssn.py
@@ -63,7 +63,7 @@ class ColorSSN(Core):
 
     def _create_file_links(self):
         output_file_names = [
-            "ssn_out.xgmml",
+            "ssn_colored.xgmml",
             "mapping_table.txt"
         ]
         file_links = [
@@ -71,13 +71,13 @@ class ColorSSN(Core):
                 "path": os.path.join(self.shared_folder, output_file_names[0]),
                 "name": output_file_names[0],
                 "label": output_file_names[0],
-                "description": "New SSN file"
+                "description": "New SSN file with cluster IDs and colors"
             },
             {
                 "path": os.path.join(self.shared_folder, output_file_names[1]),
                 "name": output_file_names[1],
                 "label": output_file_names[1],
-                "description": "New SSN file"
+                "description": "Mapping Table for Cluster IDs"
             },
         ]
 


### PR DESCRIPTION
Test handle for the EFI-EST SSN Utilities Color SSNs App (uses the run_SSN_Utils_Color_SSN backend) was failing, initially because `igraph` module wasn't installed during conda env creation (an EST repo issue). After that [PR was merged](https://github.com/EnzymeFunctionInitiative/EST/pull/110), the local tests for this app were still failing. There was miscommunication between the hardcoded file names used in colorssn.nf pipeline and those used in the _create_file_links() method in the colorssn.py script. That's been fixed for now. And the local test for this app now pass. 