### PR TITLE
41 update root spec file

### DIFF
--- a/EFIToolsKBase.spec
+++ b/EFIToolsKBase.spec
@@ -127,6 +127,10 @@ module EFIToolsKBase {
     */
     funcdef run_EFIToolsKBase(mapping<string,UnspecifiedObject> params) returns (ReportResults output) authentication required;
 
+    
+    /*
+        Actual funcdef lines calling their designed input and output objects
+    */
     funcdef run_EFI_EST_Sequence_BLAST(run_EFI_EST_Sequence_BLAST_input params) returns (ESTReportResults output) authentication required;
     
     funcdef run_EFI_EST_FASTA(run_EFI_EST_FASTA_input params) returns (ESTReportResults output) authentication required;

--- a/EFIToolsKBase.spec
+++ b/EFIToolsKBase.spec
@@ -7,21 +7,40 @@ module EFIToolsKBase {
     /* @id handle */
     typedef string handle;
 
-  
+    /* 
+	data object types to be registered 
+    */
+    
     typedef structure {
         handle edgefile_handle;
         handle fasta_handle;
+        handle evalue_handle;
+	handle seq_meta_handle;
         int edge_count;
         int unique_seq;
         float convergence_ratio;
     } BlastEdgeFile;
-    
+
     typedef structure {
         handle ssn_xgmml_handle;
         int node_count;
         int edge_count;
     } SequenceSimilarityNetwork;
+   
+    typedef structure {
+        handle ssn_xgmml_handle;
+        handle structfile_handle;
+    } SSNCreationResult;           
     
+    typedef structure {
+        handle gnd_view_file_handle;
+        string view_title;
+    } GNDViewFile;
+
+
+    /* 
+	data objects to guide development only 
+    */
     typedef structure {
         string report_name;
         string report_ref;
@@ -32,6 +51,9 @@ module EFIToolsKBase {
         string report_ref;
         string edge_ref;
     } ESTReportResults;
+
+
+
 
     /*
         This example function accepts any number of parameters and returns results in a KBaseReport

--- a/EFIToolsKBase.spec
+++ b/EFIToolsKBase.spec
@@ -52,23 +52,90 @@ module EFIToolsKBase {
         string edge_ref;
     } ESTReportResults;
 
+    /* missing filter by taxonomy options */
+    typedef structure {
+	string query_sequence;
+	string e_value; 		/* should map to an int or float */
+	string max_sequences_retrieved; /* should map to an int */
+	string sequence_database; 	/* currently unused */
+	int fragment_option; 		/* currently unused */
+	string families_to_add; 	/* currently unused */
+	string families_addition_cluster_id_format;	/* currently unused */
+	int fraction;			/* currently unused */
+	string ssn_e_value; 		/* should map to an int or float */
+    } run_EFI_EST_Sequence_BLAST_input;
 
+    typedef structure {
+	string fasta_sequence_file; 	/* really maps to a KBaseSequences.ProteinSequenceSet */
+	string header_format;		/* currently unused */
+	int fragment_option; 		/* currently unused */
+	string family_filter; 		/* currently unused */
+	string taxonomic_level; 	/* currently unused */
+	string filter_string; 		/* currently unused */
+	string families_to_add; 	/* currently unused */
+	string families_addition_cluster_id_format;	/* currently unused */
+	int fraction;			/* currently unused */
+	int domain;			/* currently unused */
+	string family_domain_bound; 	/* currently unused, should map to a bool? */
+	string region; 			/* currently unused */
+	string ssn_e_value; 		/* should map to an int or float */
+    } run_EFI_EST_FASTA_input;
+
+    typedef structure {
+	string accession_ids;
+	string accession_id_format; 	/* currently unused */
+	int fragment_option; 		/* currently unused */
+	string family_filter; 		/* currently unused */
+	string taxonomic_level; 	/* currently unused */
+	string filter_string; 		/* currently unused */
+	string families_to_add; 	/* currently unused */
+	string families_addition_cluster_id_format;	/* currently unused */
+	int fraction;			/* currently unused */
+	int domain;			/* currently unused */
+	string family_domain_bound; 	/* currently unused, should map to a bool? */
+	string region; 			/* currently unused */
+	string ssn_e_value; 		/* should map to an int or float */
+    } run_EFI_EST_Accession_IDs_input;
+
+    typedef structure {
+	string families_to_add;
+	families_addition_cluster_id_format; /* currently unused */
+	int fragment_option; 		/* currently unused */
+	string taxonomic_level; 	/* currently unused */
+	string filter_string; 		/* currently unused */
+	int fraction;			/* currently unused */
+	int domain;			/* currently unused */
+	string region; 			/* currently unused */
+	string ssn_e_value; 		/* should map to an int or float */
+    } run_EFI_EST_Families_input;
+
+    typedef structure {
+	string blast_edge_file; 	/* actually maps to a EFIToolsKBase.BlastEdgeFile data object */
+	string filter_parameter;
+	string filter_value; 		/* should map to an int or float */
+	string min_length; 		/* should map to an int */
+	string max_length; 		/* should map to an int */
+    } run_EFI_EST_SSN_Creation_input;
+
+    typedef structure {
+	string ssn_file;		/* actually maps to a EFIToolsKBase.SequenceSimilarityNetwork data object */
+    } run_EFI_SSN_Utils_Color_SSN_input;
 
 
     /*
-        This example function accepts any number of parameters and returns results in a KBaseReport
+        This example function accepts any number of parameters and returns results associated with the KBaseReport object
     */
     funcdef run_EFIToolsKBase(mapping<string,UnspecifiedObject> params) returns (ReportResults output) authentication required;
 
-    funcdef run_EFI_EST_Sequence_BLAST(mapping<string,UnspecifiedObject> params) returns (ESTReportResults output) authentication required;
+    funcdef run_EFI_EST_Sequence_BLAST(run_EFI_EST_Sequence_BLAST_input params) returns (ESTReportResults output) authentication required;
     
-    funcdef run_EFI_EST_FASTA(mapping<string,UnspecifiedObject> params) returns (ESTReportResults output) authentication required;
+    funcdef run_EFI_EST_FASTA(run_EFI_EST_FASTA_input params) returns (ESTReportResults output) authentication required;
     
-    funcdef run_EFI_EST_Families(mapping<string,UnspecifiedObject> params) returns (ESTReportResults output) authentication required;
+    funcdef run_EFI_EST_Families(run_EFI_EST_Families_input params) returns (ESTReportResults output) authentication required;
     
-    funcdef run_EFI_EST_Accession_IDs(mapping<string,UnspecifiedObject> params) returns (ESTReportResults output) authentication required;
+    funcdef run_EFI_EST_Accession_IDs(run_EFI_EST_Accession_IDs_input params) returns (ESTReportResults output) authentication required;
 
-    funcdef run_EFI_EST_SSN_Creation(mapping<string, UnspecifiedObject> params) returns (ReportResults output) authentication required;
+    funcdef run_EFI_EST_SSN_Creation(run_EFI_EST_SSN_Creation_input params) returns (ReportResults output) authentication required;
 
-    funcdef run_EFI_SSN_Utils_Color_SSN(mapping<string, UnspecifiedObject> params) returns (ReportResults output) authentication required;
+    funcdef run_EFI_SSN_Utils_Color_SSN(run_EFI_SSN_Utils_Color_SSN_input params) returns (ReportResults output) authentication required;
 };


### PR DESCRIPTION
This PR is basically an update to the design docs for the EFIToolsKBase Apps. The core spec file in this repo is not explicitly used to add new data object types. Rather, this file communicates the attributes/elements associated with each data object as well as what input and output objects are required by the Apps' UI functions (which map to the backend codes). 

Once merged, this file will be used to keep track of which UI fields are mapped to the backend code. Similarly, as new Apps have backend implementations, their designs will be added to this file to communicate how it is implemented, remaining features to be incorporated, etc. 