### PR TITLE
69 update release notes and versioning

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,30 @@
 # EFIToolsKBase release notes
 =========================================
 
+Current EST repo commit hash: 8374e804eb9b21b508559a98b7a57e24882c48ff
+Current EFI Database version: 101 (https://efi.igb.illinois.edu/downloads/databases/20241017/)
+Current EFIToolsKBase commit hash registered on KBase: 54b2d1bf9efdfffac48c15003749d926ca5d588a 
+
+
+0.3.0
+-----
+* Updates in the EST nextflow-tests branch caused errors in the KBase backend codes. Fixed those bugs. 
+* Update the root EFIToolsKBase.spec file to more exactly match the design of the Apps' UI spec.json files. 
+
+0.2.0
+-----
+* Backend code for EFI-EST Sequence BLAST app developed. 
+* Backend code for EFI-EST Families app developed. 
+* Backend code for EFI-EST FASTA app developed. 
+* Backend code for EFI-EST Accession IDs app developed. 
+* Backend code for EFI-EST SSN Creation app developed. 
+* Backend code for EFI-EST SSN Utilities Color SSN app developed. 
+
+0.1.0
+-----
+* Skeletons of EFI Apps developed.
+
+
 0.0.0
 -----
-* Module created by kb-sdk init
+* Module created by kb-sdk init.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,7 +6,7 @@ Current EFI Database version: 101 (https://efi.igb.illinois.edu/downloads/databa
 Current EFIToolsKBase commit hash registered on KBase: 54b2d1bf9efdfffac48c15003749d926ca5d588a 
 
 
-0.3.0
+0.3.0, 2025-01-21
 -----
 * Updates in the EST nextflow-tests branch caused errors in the KBase backend codes. Fixed those bugs. 
 * Update the root EFIToolsKBase.spec file to more exactly match the design of the Apps' UI spec.json files. 

--- a/kbase.yml
+++ b/kbase.yml
@@ -8,7 +8,7 @@ service-language:
     python
 
 module-version:
-    0.2.1
+    0.3.0
 
 data-version:
     0.2.1


### PR DESCRIPTION
Updates the relevant root files for the EFIToolsKBase module. Use this as a starting off point for maintaining better records of progress and versioning.  

Note, I'm leaving individual app's versioning alone; follow good versioning practice for apps as they get worked on individually. This means versioning of Apps may not follow the versioning of the module. That's fine. 