### PR TITLE
86 centralize nf config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,8 +31,8 @@ RUN curl -o /opt/install_nextflow.sh https://get.nextflow.io && chmod +x /opt/in
 
 # install the EST repo
 # update the commitHash variable to point to a specific commit (short or long) or branch name
-ARG commitHash=6f2bce4fbac77323bff4825ef3b5bd2ef6d3b622
-#ARG commitHash=6f2bce4
+ARG commitHash=a805a68b97fa3cc2491b2942b55273fbeb73f9c7
+#ARG commitHash=a805a68
 #ARG commitHash=nextflow-test
 RUN git clone https://github.com/EnzymeFunctionInitiative/EST.git && \
     cd EST && \

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,9 +1,14 @@
 # EFIToolsKBase release notes
 =========================================
 
-Current EST repo commit hash: 6f2bce4fbac77323bff4825ef3b5bd2ef6d3b622
+Current EST repo commit hash: a805a68b97fa3cc2491b2942b55273fbeb73f9c7
 Current EFI Database version: 101 (https://efi.igb.illinois.edu/downloads/databases/20241017/)
 Current EFIToolsKBase commit hash registered on KBase: d649e6438f291077cb81b228eabc0b9ede095da1
+
+0.5.0, 2025-09-24
+-----------------
+* Update the EST commit hash in the DockerFile.
+* Centralize the use of the nextflow config file.
 
 0.4.5, 2025-09-09
 -----------------

--- a/kbase.yml
+++ b/kbase.yml
@@ -8,7 +8,7 @@ service-language:
     python
 
 module-version:
-    0.4.5
+    0.5.0
 
 data-version:
     0.3.1

--- a/lib/EFIToolsKBase/EFIToolsKBaseImpl.py
+++ b/lib/EFIToolsKBase/EFIToolsKBaseImpl.py
@@ -37,7 +37,7 @@ class EFIToolsKBase:
     # state. A method could easily clobber the state set by another while
     # the latter method is running.
     ######################################### noqa
-    VERSION = "0.4.5"
+    VERSION = "0.5.0"
     GIT_URL = "git@github.com:EnzymeFunctionInitiative/EFIToolsKBase.git"
     # this will always be outdated...
     GIT_COMMIT_HASH = "4777308f04a169666b063f3eb576263da162c9ae"

--- a/lib/EFIToolsKBase/est_wrappers/est.py
+++ b/lib/EFIToolsKBase/est_wrappers/est.py
@@ -25,7 +25,7 @@ class EFIEST(Core):
         self.report = self.clients.KBaseReport
         self.dfu = self.clients.DataFileUtil
         self.wsClient = self.clients.Workspace
-        self.flow = NextflowRunner("pipelines/est/est.nf", "est/kbase.config")
+        self.flow = NextflowRunner("pipelines/est/est.nf", "kbase.config")
 
     ###########################################################################
     # interface method

--- a/lib/EFIToolsKBase/est_wrappers/ssn_creation.py
+++ b/lib/EFIToolsKBase/est_wrappers/ssn_creation.py
@@ -80,7 +80,7 @@ class SSNCreation(Core):
         self.wsClient = self.clients.Workspace
         self.flow = NextflowRunner(
             "pipelines/generatessn/generatessn.nf",
-            "generatessn/kbase.config"
+            "kbase.config"
         )
 
 

--- a/lib/EFIToolsKBase/gnt_wrappers/gnt.py
+++ b/lib/EFIToolsKBase/gnt_wrappers/gnt.py
@@ -27,7 +27,7 @@ class EFIGNT(Core):
         self.report = self.clients.KBaseReport
         self.dfu = self.clients.DataFileUtil
         self.wsClient = self.clients.Workspace
-        self.flow = NextflowRunner("pipelines/gnt/gnt.nf", "gnt/kbase.config")
+        self.flow = NextflowRunner("pipelines/gnt/gnt.nf", "kbase.config")
 
 
     def run_gnt_pipeline(self, params: Dict[str,str]) -> Dict[str,str]:

--- a/lib/EFIToolsKBase/ssnutil_wrappers/colorssn.py
+++ b/lib/EFIToolsKBase/ssnutil_wrappers/colorssn.py
@@ -20,7 +20,7 @@ class ColorSSN(Core):
         # Here we adjust the instance attributes for our convenience.
         self.report = self.clients.KBaseReport
         self.dfu = self.clients.DataFileUtil
-        self.flow = NextflowRunner("pipelines/colorssn/colorssn.nf", "generatessn/kbase.config")
+        self.flow = NextflowRunner("pipelines/colorssn/colorssn.nf", "kbase.config")
 
     def do_analysis(self, params):
         ssn_file_obj = self.dfu.get_objects({"object_refs": [params["ssn_file"]]})["data"][0]


### PR DESCRIPTION
- updated the git commit hash for the EST repo to a805a68b97fa3cc2491b2942b55273fbeb73f9c7
- updated version numbering and release notes
- in response to changes in the EST repo, all instances of the `NextflowRunner` use a shared config file path.

closes #86 

Running local `kb-sdk test` now to make sure all expected Apps are passing. 